### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/.changeset/a2a-max-concurrent-tasks.md
+++ b/.changeset/a2a-max-concurrent-tasks.md
@@ -1,0 +1,5 @@
+---
+"@cycgraph/orchestrator": patch
+---
+
+The `max_concurrent_tasks` field on an A2A server registry entry is now enforced: the `a2a` node holds a per-server slot for the whole remote exchange, so a `map`, voting, or parallel-branch graph queues instead of firing every branch at one remote agent at once. Servers without the field are unchanged and still fan out freely.

--- a/packages/orchestrator/src/a2a/concurrency.ts
+++ b/packages/orchestrator/src/a2a/concurrency.ts
@@ -1,0 +1,79 @@
+/**
+ * A2A Per-Server Concurrency Cap
+ *
+ * Enforces `max_concurrent_tasks` from an {@link A2AServerEntry}: the number
+ * of tasks this process may have in flight against one remote agent at a
+ * time. Without it a `map`, voting, or parallel-branch graph fires every
+ * branch at once and can overwhelm a shared or rate-limited agent.
+ *
+ * The limiter is module-scoped rather than per-run on purpose. The thing
+ * being protected is the REMOTE agent, so two concurrent runs delegating to
+ * the same server must share one budget — a per-run limiter would multiply
+ * the configured cap by the number of runs in flight.
+ *
+ * Keyed by server id AND agent card URL: two registry entries that resolve
+ * to the same endpoint are the same remote agent and share a budget, while
+ * a tenant-specific entry that reuses an id but points elsewhere gets its
+ * own. Absent `max_concurrent_tasks` means unlimited, and allocates nothing.
+ *
+ * @module a2a/concurrency
+ */
+
+import { Semaphore } from '../mcp/semaphore.js';
+import type { A2AServerEntry } from './schema.js';
+
+/** Cached limiter plus the limit it was built for, so edits take effect. */
+interface ServerLimiter {
+  limit: number;
+  semaphore: Semaphore;
+}
+
+const limiters = new Map<string, ServerLimiter>();
+
+/** Identity of the remote agent being protected, not of the registry row. */
+function limiterKey(server: Pick<A2AServerEntry, 'id' | 'agent_card_url'>): string {
+  return `${server.id}\u0000${server.agent_card_url}`;
+}
+
+/**
+ * Resolve (and lazily create) the limiter for a server. Returns `undefined`
+ * when the entry sets no cap, so the unlimited path stays allocation-free.
+ *
+ * A registry entry whose cap changed is re-limited: the new semaphore starts
+ * fresh while tasks already holding the old one drain against it, so the two
+ * caps overlap briefly rather than the edit being ignored outright.
+ */
+export function getA2AServerSemaphore(
+  server: Pick<A2AServerEntry, 'id' | 'agent_card_url' | 'max_concurrent_tasks'>,
+): Semaphore | undefined {
+  const limit = server.max_concurrent_tasks;
+  if (!limit || limit < 1) return undefined;
+
+  const key = limiterKey(server);
+  const existing = limiters.get(key);
+  if (existing && existing.limit === limit) return existing.semaphore;
+
+  const semaphore = new Semaphore(limit);
+  limiters.set(key, { limit, semaphore });
+  return semaphore;
+}
+
+/**
+ * Run `fn` while holding one of the server's task slots, releasing it even
+ * if `fn` throws. Uncapped servers call straight through.
+ */
+export async function withA2AServerConcurrency<T>(
+  server: Pick<A2AServerEntry, 'id' | 'agent_card_url' | 'max_concurrent_tasks'>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const semaphore = getA2AServerSemaphore(server);
+  return semaphore ? semaphore.run(fn) : fn();
+}
+
+/**
+ * Drop every cached limiter. For tests that need one suite's fan-out not to
+ * inherit permits held by another; not part of the runtime path.
+ */
+export function resetA2AServerConcurrency(): void {
+  limiters.clear();
+}

--- a/packages/orchestrator/src/execution/nodes/a2a.ts
+++ b/packages/orchestrator/src/execution/nodes/a2a.ts
@@ -29,6 +29,7 @@ import { nodeIdempotencyKey } from './idempotency-key.js';
 import { A2AInterfaceError, A2ATaskFailedError } from './errors.js';
 import { mapInbound, mapOutbound, type BoundaryFailure } from './boundary.js';
 import { resolveAuthHeaders } from '../../a2a/schema.js';
+import { withA2AServerConcurrency } from '../../a2a/concurrency.js';
 import type { A2AArtifact, A2ATaskResult } from '../../a2a/client.js';
 import { markTainted, valueBytes } from '../../security/taint.js';
 import type { TaintRegistry } from '../../state/state.js';
@@ -120,7 +121,7 @@ export async function executeA2ANode(
   let result: A2ATaskResult;
   try {
     // Inner span carrying the remote-call attributes; `node.execute.a2a` wraps above.
-    result = await withSpan(tracer, 'a2a.task', async (span) => {
+    const runRemoteTask = () => withSpan(tracer, 'a2a.task', async (span) => {
       span.setAttribute('a2a.server_id', config.server_id);
       span.setAttribute('a2a.resumed', Boolean(resumingTaskId));
       span.setAttribute('a2a.trace_propagated', server.propagate_trace_context);
@@ -148,6 +149,12 @@ export async function executeA2ANode(
       span.setAttribute('a2a.state', taskResult.state);
       return taskResult;
     });
+
+    // Per-server cap on tasks in flight (`max_concurrent_tasks`): a map or
+    // voting fan-out queues here instead of hitting one remote agent with
+    // every branch at once. The slot is held for the whole exchange, and an
+    // uncapped server calls straight through.
+    result = await withA2AServerConcurrency(server, runRemoteTask);
   } catch (error) {
     // A throw is a transport failure; a task that ran and ended badly returns as a state.
     logger.error('a2a_transport_failed', error as Error, {

--- a/packages/orchestrator/test/a2a-node.test.ts
+++ b/packages/orchestrator/test/a2a-node.test.ts
@@ -12,6 +12,7 @@ import { executeA2ANode } from '../src/execution/nodes/a2a.js';
 import { A2ATaskFailedError } from '../src/execution/nodes/errors.js';
 import { NodeConfigError } from '../src/execution/errors.js';
 import { InMemoryA2AServerRegistry } from '../src/a2a/in-memory-registry.js';
+import { resetA2AServerConcurrency } from '../src/a2a/concurrency.js';
 import { a2a } from '../src/authoring/a2a.js';
 import { graph } from '../src/authoring/graph.js';
 import { impliedResultKeys } from '../src/security/effective-permissions.js';
@@ -195,6 +196,67 @@ describe('executeA2ANode', () => {
       .rejects.toThrow(/permitted to use/);
   });
 
+});
+
+describe('executeA2ANode — per-server concurrency cap', () => {
+  /** Yield past the microtask queue so queued branches can start. */
+  const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  /** Client whose tasks stay in flight until the test releases them. */
+  function gatedClient(gate: { release: Array<() => void>; inFlight: number; peak: number }): A2AClient {
+    return {
+      runTask: async () => {
+        gate.inFlight += 1;
+        gate.peak = Math.max(gate.peak, gate.inFlight);
+        await new Promise<void>((resolve) => gate.release.push(resolve));
+        gate.inFlight -= 1;
+        return { taskId: 'task-1', state: 'completed', artifacts: [] };
+      },
+      resumeTask: async () => ({ taskId: 'task-1', state: 'completed', artifacts: [] }),
+    };
+  }
+
+  it('holds fan-out to max_concurrent_tasks against one server', async () => {
+    resetA2AServerConcurrency();
+    const registry = await registryWith({ maxConcurrentTasks: 1 });
+    const gate = { release: [] as Array<() => void>, inFlight: 0, peak: 0 };
+    const client = gatedClient(gate);
+
+    const branches = Array.from({ length: 3 }, async () =>
+      executeA2ANode(node(), stateView(), 1, await ctxWith(client, registry)));
+
+    await tick();
+    // Two branches are queued on the semaphore, not in flight against the agent.
+    expect(gate.release.length).toBe(1);
+
+    for (let i = 0; i < 3; i++) {
+      gate.release.shift()?.();
+      await tick();
+      await tick();
+    }
+
+    await Promise.all(branches);
+    expect(gate.peak).toBe(1);
+  });
+
+  it('leaves a server without a cap free to fan out', async () => {
+    resetA2AServerConcurrency();
+    const registry = await registryWith({ id: 'uncapped-service', agentCardUrl: CARD_URL });
+    const gate = { release: [] as Array<() => void>, inFlight: 0, peak: 0 };
+    const uncapped = node({
+      a2a_config: { server_id: 'uncapped-service', input_mapping: {}, output_mapping: {} },
+    } as Partial<GraphNode>);
+
+    const branches = Array.from({ length: 3 }, async () =>
+      executeA2ANode(uncapped, stateView(), 1, await ctxWith(gatedClient(gate), registry)));
+
+    await tick();
+    expect(gate.release.length).toBe(3);
+
+    for (const release of gate.release.splice(0)) release();
+    await Promise.all(branches);
+    expect(gate.peak).toBe(3);
+  });
 });
 
 describe('executeA2ANode — non-completed task states', () => {


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #159. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #159. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
