### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/apps/docs/src/content/docs/docs/patterns/a2a.md
+++ b/apps/docs/src/content/docs/docs/patterns/a2a.md
@@ -90,6 +90,8 @@ npm install @cycgraph/a2a
 
 Supplying your own implementation of the port is enough to swap transports or test without a network.
 
+A client resolves each Agent Card once per `agentCardUrl` and caches it for its own lifetime, with no TTL and no invalidation on success — only a failed resolution is evicted. Sharing one `createA2AClient()` across a long-lived runner therefore pins the card that was fetched first: a remote that rotates its skills or repoints the URL at a new deployment is not seen until you build a fresh client or restart the process. Construct a client per run when a card is expected to change under you.
+
 ## Publishing your own graph
 
 A graph's declared interface projects to an Agent Card, so others can discover it the same way:

--- a/packages/a2a/README.md
+++ b/packages/a2a/README.md
@@ -69,6 +69,21 @@ response cannot leak one.
 - Budget and capability ceilings stop at the network. Remote spend is
   unmetered, bounded only by timeouts and the failure policy.
 
+## Agent Card caching
+
+A client resolves each Agent Card once per `agentCardUrl` and keeps it for
+the lifetime of that `createA2AClient()` instance. There is no TTL and no
+invalidation on success; only a failed resolution is evicted, so a
+transient fetch fault never outlives the request that hit it.
+
+Because the usage above hands one client to a runner for the whole run,
+a card that changes on the remote side — rotated skills, new capabilities,
+or the same URL repointed at a different deployment — is not picked up
+until you build a fresh client with `createA2AClient()` or restart the
+process. If an agent's card is expected to change while your process is
+up, construct a client per run rather than sharing one. Requests
+themselves are never cached: auth and trace headers are resolved per call.
+
 ## Trace context
 
 Set `propagateTraceContext: true` on a registry entry to send W3C


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #160. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #160. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
