### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/.changeset/a2a-bare-message-reply.md
+++ b/.changeset/a2a-bare-message-reply.md
@@ -1,0 +1,5 @@
+---
+"@cycgraph/a2a": patch
+---
+
+Translate a bare `Message` reply from `message/send` into a completed task result whose `response` artifact carries the reply's parts. Agents that answer statelessly without creating a task no longer fail every `a2a` node with a fabricated failure that discarded the reply.

--- a/packages/a2a/src/translate.ts
+++ b/packages/a2a/src/translate.ts
@@ -1,7 +1,8 @@
 /**
  * Wire-to-engine translation
  *
- * Turns what the SDK hands back — a parsed protocol `Task` — into the
+ * Turns what the SDK hands back — a parsed protocol `Task`, or a bare
+ * `Message` for an agent that answers without creating one — into the
  * engine's `A2ATaskResult`. The translation is lossy in one deliberate way:
  * an artifact's `Part[]` collapses to a single value, by the rules on
  * {@link partsToValue}.
@@ -34,6 +35,38 @@ interface WireTask {
     message?: { parts?: WirePart[] };
   };
   artifacts?: WireArtifact[];
+}
+
+/** The slice of a protocol `Message` this adapter reads. */
+export interface WireMessage {
+  taskId?: string;
+  role?: unknown;
+  parts?: WirePart[];
+}
+
+/**
+ * The artifact name a bare `Message` reply lands under, since the protocol
+ * gives such a reply no name of its own. `output_mapping` matches on it.
+ */
+const MESSAGE_ARTIFACT_NAME = 'response';
+
+/**
+ * Whether the object `message/send` returned is a bare `Message` rather
+ * than a `Task`.
+ *
+ * The SDK's own `SendMessageResult` is `Message | Task`: an agent that
+ * holds no state answers with the reply itself and never creates a task.
+ * Only a `Task` carries `id`/`status`, and only a `Message` carries `role`
+ * beside its own `parts`, so the two shapes are distinguishable without a
+ * discriminator field.
+ */
+export function isWireMessage(value: unknown): value is WireMessage {
+  if (typeof value !== 'object' || value === null) return false;
+  const wire = value as WireTask & WireMessage;
+  return wire.id === undefined
+    && wire.status === undefined
+    && wire.role !== undefined
+    && Array.isArray(wire.parts);
 }
 
 /**
@@ -85,16 +118,32 @@ function statusMessage(task: WireTask): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-/** Translate an SDK task into the engine's shape. */
-export function toResult(task: unknown): A2ATaskResult {
-  const wire = task as WireTask;
-  const state = normalizeState(wire.status?.state);
-  const message = statusMessage(wire);
+/**
+ * A bare `Message` reply IS the answer: the agent created no task, so there
+ * is no state to normalize and nothing left to wait for. Sending it down the
+ * task path would read the absent `status` as `failed` and drop the reply's
+ * parts, which are the whole content of the exchange.
+ */
+function messageResult(message: WireMessage): A2ATaskResult {
+  return {
+    taskId: message.taskId ?? '',
+    state: 'completed',
+    artifacts: [{ name: MESSAGE_ARTIFACT_NAME, value: partsToValue(message.parts ?? []) }],
+  };
+}
+
+/** Translate what the SDK returned — a task or a bare message — into the engine's shape. */
+export function toResult(wire: unknown): A2ATaskResult {
+  if (isWireMessage(wire)) return messageResult(wire);
+
+  const task = wire as WireTask;
+  const state = normalizeState(task.status?.state);
+  const message = statusMessage(task);
 
   return {
-    taskId: wire.id ?? '',
+    taskId: task.id ?? '',
     state,
-    artifacts: state === 'completed' ? toArtifacts(wire.artifacts ?? []) : [],
+    artifacts: state === 'completed' ? toArtifacts(task.artifacts ?? []) : [],
     ...(message ? { message } : {}),
   };
 }

--- a/packages/a2a/test/client.test.ts
+++ b/packages/a2a/test/client.test.ts
@@ -113,6 +113,44 @@ describe('toResult', () => {
     expect(result.message).toBe('Which region?');
   });
 
+  it('completes a bare message reply with its parts as the response artifact', () => {
+    const result = toResult({
+      taskId: 'task-7',
+      role: 'ROLE_AGENT',
+      parts: [textPart('the answer')],
+    });
+
+    expect(result).toEqual({
+      taskId: 'task-7',
+      state: 'completed',
+      artifacts: [{ name: 'response', value: 'the answer' }],
+    });
+  });
+
+  it('completes a bare message reply that carries no task id', () => {
+    const result = toResult({
+      role: 'ROLE_AGENT',
+      parts: [dataPart({ score: 0.5 })],
+    });
+
+    expect(result).toEqual({
+      taskId: '',
+      state: 'completed',
+      artifacts: [{ name: 'response', value: { score: 0.5 } }],
+    });
+  });
+
+  it('keeps a task carrying both parts and status on the task path', () => {
+    const result = toResult({
+      id: 'task-8',
+      status: { state: 'TASK_STATE_FAILED' },
+      role: 'ROLE_AGENT',
+      parts: [textPart('ignored')],
+    });
+
+    expect(result).toEqual({ taskId: 'task-8', state: 'failed', artifacts: [] });
+  });
+
 });
 
 describe('createA2AClient', () => {


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #169. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #169. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
