### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/.changeset/a2a-multipart-status-message.md
+++ b/.changeset/a2a-multipart-status-message.md
@@ -1,0 +1,5 @@
+---
+"@cycgraph/a2a": patch
+---
+
+A multi-part `status.message` is no longer dropped: every part now contributes to `A2ATaskResult.message`, joined by newline in wire order, so an `input-required` pause still shows the remote agent's question when it arrives as more than one part.

--- a/packages/a2a/src/translate.ts
+++ b/packages/a2a/src/translate.ts
@@ -110,12 +110,26 @@ function toArtifacts(artifacts: readonly WireArtifact[]): A2AArtifact[] {
   }));
 }
 
-/** The human-readable detail a non-completed task carries. */
+/**
+ * The human-readable detail a non-completed task carries.
+ *
+ * Every part contributes, joined by newline in wire order: the protocol lets
+ * an agent split one question across several parts, and an `input-required`
+ * pause has nothing else to show the human, so dropping any part can drop
+ * the question itself.
+ */
 function statusMessage(task: WireTask): string | undefined {
   const parts = task.status?.message?.parts;
   if (!parts) return undefined;
-  const value = partsToValue(parts);
-  return typeof value === 'string' ? value : undefined;
+  const text = parts.map(partToText).filter((piece) => piece.length > 0).join('\n');
+  return text.length > 0 ? text : undefined;
+}
+
+/** Render one status part as display text, structured parts as their JSON. */
+function partToText(part: WirePart): string {
+  const value = partToValue(part);
+  if (value === null || value === undefined) return '';
+  return typeof value === 'string' ? value : JSON.stringify(value);
 }
 
 /**

--- a/packages/a2a/test/client.test.ts
+++ b/packages/a2a/test/client.test.ts
@@ -119,6 +119,36 @@ describe('toResult', () => {
     expect(result.message).toBe('Which region?');
   });
 
+  it('keeps every part of a multi-part status message so the question survives', () => {
+    const result = toResult({
+      id: 'task-1',
+      status: {
+        state: 'TASK_STATE_INPUT_REQUIRED',
+        message: { parts: [textPart('Which region?'), dataPart({ options: ['EMEA', 'APAC'] })] },
+      },
+    });
+
+    expect(result.message).toBe('Which region?\n{"options":["EMEA","APAC"]}');
+  });
+
+  it('renders a status message made only of a data part as its json', () => {
+    const result = toResult({
+      id: 'task-1',
+      status: { state: 'TASK_STATE_INPUT_REQUIRED', message: { parts: [dataPart({ question: 'region?' })] } },
+    });
+
+    expect(result.message).toBe('{"question":"region?"}');
+  });
+
+  it('omits the message when the status message carries no renderable parts', () => {
+    const result = toResult({
+      id: 'task-1',
+      status: { state: 'TASK_STATE_INPUT_REQUIRED', message: { parts: [] } },
+    });
+
+    expect(result.message).toBeUndefined();
+  });
+
   it('completes a bare message reply with its parts as the response artifact', () => {
     const result = toResult({
       taskId: 'task-7',


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #171. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #171. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
