### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/.changeset/a2a-card-cache-header-key.md
+++ b/.changeset/a2a-card-cache-header-key.md
@@ -1,0 +1,5 @@
+---
+"@cycgraph/a2a": patch
+---
+
+The Agent Card cache is now keyed by agent card URL plus the headers the card was fetched with, so two registry entries that share one `agent_card_url` but use different credentials each resolve the card with their own auth instead of silently reusing the first caller's cached card.

--- a/packages/a2a/src/connection.ts
+++ b/packages/a2a/src/connection.ts
@@ -3,10 +3,10 @@
  *
  * A client is built per call because auth and trace headers are resolved
  * per call; caching one would freeze the first caller's headers into every
- * later request. The Agent Card is cached per URL, fetched with the same
- * per-server headers as every other request (a registry entry's auth gate
- * covers its card endpoint too), and a failed resolution is evicted so a
- * transient fault never outlives the request that hit it.
+ * later request. The Agent Card is cached per URL AND header set, fetched
+ * with the same per-server headers as every other request (a registry
+ * entry's auth gate covers its card endpoint too), and a failed resolution
+ * is evicted so a transient fault never outlives the request that hit it.
  *
  * @module connection
  */
@@ -26,7 +26,35 @@ export type CreateSdkClient = (
   signal?: AbortSignal,
 ) => Promise<SdkClient>;
 
-/** Default {@link CreateSdkClient}, with a per-URL Agent Card cache scoped to this factory. */
+/**
+ * Trace-context headers, excluded from the card cache key: they change on
+ * every call and identify our trace, not the caller's credentials, so
+ * including them would reduce the cache to one fetch per request.
+ */
+const TRACE_HEADERS = new Set(['traceparent', 'tracestate', 'baggage']);
+
+/**
+ * Cache key for one Agent Card resolution.
+ *
+ * The URL alone is not the identity of a card fetch: two registry entries
+ * may share one `agent_card_url` and differ in `auth`, so a card resolved
+ * with one entry's credentials must never be served to the other. Header
+ * names are lowercased and sorted so an equivalent header set yields one
+ * key, and the key is a JSON array so a header value containing the
+ * delimiter cannot forge another entry's key.
+ */
+function cardKey(agentCardUrl: string, headers: Record<string, string>): string {
+  const identifying = Object.entries(headers)
+    .map(([name, value]) => [name.toLowerCase(), value] as const)
+    .filter(([name]) => !TRACE_HEADERS.has(name))
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return JSON.stringify([agentCardUrl, identifying]);
+}
+
+/**
+ * Default {@link CreateSdkClient}, with an Agent Card cache scoped to this
+ * factory and keyed by URL plus the headers the card was fetched with.
+ */
 export function sdkClientFactory(): CreateSdkClient {
   const cards = new Map<string, Promise<unknown>>();
 
@@ -41,7 +69,8 @@ export function sdkClientFactory(): CreateSdkClient {
           : {}),
       });
 
-    let card = cards.get(agentCardUrl);
+    const key = cardKey(agentCardUrl, headers);
+    let card = cards.get(key);
     if (!card) {
       // The promise is cached, so concurrent first calls share one fetch.
       // It carries the caller's headers but not its signal: a shared
@@ -54,9 +83,9 @@ export function sdkClientFactory(): CreateSdkClient {
         });
       const resolving = new DefaultAgentCardResolver({ fetchImpl: cardFetch })
         .resolve(agentCardUrl, '');
-      cards.set(agentCardUrl, resolving);
+      cards.set(key, resolving);
       resolving.catch(() => {
-        if (cards.get(agentCardUrl) === resolving) cards.delete(agentCardUrl);
+        if (cards.get(key) === resolving) cards.delete(key);
       });
       card = resolving;
     }

--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -54,6 +54,41 @@ describe('sdkClientFactory', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('resolves the card again for the same url with different headers', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => cardResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    await settled(create(CARD_URL, { authorization: 'Bearer tenant-a' }));
+    await settled(create(CARD_URL, { authorization: 'Bearer tenant-b' }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((fetchMock.mock.calls[1]![1]?.headers as Record<string, string>).authorization)
+      .toBe('Bearer tenant-b');
+  });
+
+  it('shares one card fetch for equivalent header sets', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => cardResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    await settled(create(CARD_URL, { Authorization: 'Bearer sesame', 'x-api-key': '1' }));
+    await settled(create(CARD_URL, { 'x-api-key': '1', authorization: 'Bearer sesame' }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one card fetch across calls differing only in trace headers', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => cardResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    await settled(create(CARD_URL, { authorization: 'Bearer sesame', traceparent: '00-a-1-01' }));
+    await settled(create(CARD_URL, { authorization: 'Bearer sesame', traceparent: '00-b-2-01' }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('retries card resolution after a failure instead of caching the rejection', async () => {
     const fetchMock = vi.fn()
       .mockRejectedValueOnce(new Error('connection refused'))


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #172. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #172. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
