### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/packages/a2a/test/task-state.test.ts
+++ b/packages/a2a/test/task-state.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for task-state translation of the protobuf enum numbers that
+ * `Task.fromJSON` actually emits on the wire.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isPending, normalizeState } from '../src/task-state.js';
+
+describe('normalizeState', () => {
+  it('maps each settled protobuf enum number to its engine state', () => {
+    expect(normalizeState(3)).toBe('completed');
+    expect(normalizeState(4)).toBe('failed');
+    expect(normalizeState(5)).toBe('canceled');
+    expect(normalizeState(6)).toBe('input-required');
+    expect(normalizeState(7)).toBe('rejected');
+    expect(normalizeState(8)).toBe('auth-required');
+  });
+
+  it('maps a settled enum number written as a string to the same state', () => {
+    expect(normalizeState('3')).toBe('completed');
+    expect(normalizeState('4')).toBe('failed');
+    expect(normalizeState('5')).toBe('canceled');
+    expect(normalizeState('6')).toBe('input-required');
+    expect(normalizeState('7')).toBe('rejected');
+    expect(normalizeState('8')).toBe('auth-required');
+  });
+
+  it('maps the enum number, proto name and json wire form of a state identically', () => {
+    expect([normalizeState(6), normalizeState('TASK_STATE_INPUT_REQUIRED'), normalizeState('input-required')])
+      .toEqual(['input-required', 'input-required', 'input-required']);
+    expect([normalizeState(7), normalizeState('TASK_STATE_REJECTED'), normalizeState('rejected')])
+      .toEqual(['rejected', 'rejected', 'rejected']);
+    expect([normalizeState(8), normalizeState('TASK_STATE_AUTH_REQUIRED'), normalizeState('auth-required')])
+      .toEqual(['auth-required', 'auth-required', 'auth-required']);
+  });
+
+  it('maps a running enum number to failure so a deadline never reads as success', () => {
+    expect(normalizeState(1)).toBe('failed');
+    expect(normalizeState(2)).toBe('failed');
+  });
+
+  it('maps the unspecified and unknown enum numbers to failure', () => {
+    expect(normalizeState(0)).toBe('failed');
+    expect(normalizeState(9)).toBe('failed');
+  });
+});
+
+describe('isPending', () => {
+  it('treats the running enum numbers as pending', () => {
+    expect(isPending(1)).toBe(true);
+    expect(isPending(2)).toBe(true);
+  });
+
+  it('treats a running enum number written as a string as pending', () => {
+    expect(isPending('1')).toBe(true);
+    expect(isPending('2')).toBe(true);
+  });
+
+  it('treats the proto names and json wire forms of the running states as pending', () => {
+    expect(isPending('TASK_STATE_SUBMITTED')).toBe(true);
+    expect(isPending('submitted')).toBe(true);
+    expect(isPending('TASK_STATE_WORKING')).toBe(true);
+    expect(isPending('working')).toBe(true);
+  });
+
+  it('treats every settled enum number as not pending', () => {
+    expect(isPending(3)).toBe(false);
+    expect(isPending(4)).toBe(false);
+    expect(isPending(5)).toBe(false);
+    expect(isPending(6)).toBe(false);
+    expect(isPending(7)).toBe(false);
+    expect(isPending(8)).toBe(false);
+  });
+
+  it('treats the unspecified and unknown enum numbers as not pending', () => {
+    expect(isPending(0)).toBe(false);
+    expect(isPending(9)).toBe(false);
+    expect(isPending(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #185. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #185. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
