### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/packages/a2a/src/connection.ts
+++ b/packages/a2a/src/connection.ts
@@ -93,6 +93,26 @@ function assertPublicEndpoints(card: unknown): void {
 }
 
 /**
+ * The fetch every request of one call goes through: `headers` are applied
+ * over whatever the SDK set, and `signal`, when given, bounds the request.
+ *
+ * A delivery bound is COMBINED with the SDK's own `init.signal` rather
+ * than replacing it, so neither the SDK's per-request cancellation nor
+ * the caller's deadline can be lost. Omitting `signal` leaves the SDK's
+ * own signal, if any, exactly as it came.
+ */
+export function requestFetch(headers: Record<string, string>, signal?: AbortSignal): typeof fetch {
+  return (input, init) =>
+    fetch(input, {
+      ...init,
+      headers: { ...(init?.headers as Record<string, string>), ...headers },
+      ...(signal !== undefined
+        ? { signal: init?.signal ? AbortSignal.any([init.signal, signal]) : signal }
+        : {}),
+    });
+}
+
+/**
  * Default {@link CreateSdkClient}, with an Agent Card cache scoped to this
  * factory and keyed by URL plus the headers the card was fetched with.
  */
@@ -100,15 +120,7 @@ export function sdkClientFactory(): CreateSdkClient {
   const cards = new Map<string, Promise<unknown>>();
 
   return async (agentCardUrl, headers, signal) => {
-    const fetchImpl: typeof fetch = (input, init) =>
-      fetch(input, {
-        ...init,
-        headers: { ...(init?.headers as Record<string, string>), ...headers },
-        // Combine rather than replace: the SDK may carry its own signal.
-        ...(signal !== undefined
-          ? { signal: init?.signal ? AbortSignal.any([init.signal, signal]) : signal }
-          : {}),
-      });
+    const fetchImpl = requestFetch(headers, signal);
 
     const key = cardKey(agentCardUrl, headers);
     let card = cards.get(key);
@@ -117,11 +129,7 @@ export function sdkClientFactory(): CreateSdkClient {
       // It carries the caller's headers but not its signal: a shared
       // promise must not be rejected for everyone by one caller's abort.
       // deliver() still bounds the caller itself via raceAbort.
-      const cardFetch: typeof fetch = (input, init) =>
-        fetch(input, {
-          ...init,
-          headers: { ...(init?.headers as Record<string, string>), ...headers },
-        });
+      const cardFetch = requestFetch(headers);
       const resolving = new DefaultAgentCardResolver({ fetchImpl: cardFetch })
         .resolve(agentCardUrl, '');
       cards.set(key, resolving);

--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for the SDK client factory's Agent Card handling.
+ * Tests for the SDK client factory's Agent Card handling and for the
+ * per-request fetch its transport issues.
  */
 
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import { sdkClientFactory } from '../src/connection.js';
+import { requestFetch, sdkClientFactory } from '../src/connection.js';
 
 const CARD_URL = 'http://agent.example';
 
@@ -130,5 +131,73 @@ describe('sdkClientFactory', () => {
     await settled(create(CARD_URL, {}));
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('requestFetch', () => {
+  function okFetch() {
+    return vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response('{}'));
+  }
+
+  function sentSignal(fetchMock: ReturnType<typeof okFetch>): AbortSignal {
+    return fetchMock.mock.calls[0]![1]!.signal!;
+  }
+
+  it('aborts the request when the delivery bound fires and the sdk carries its own signal', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const sdk = new AbortController();
+    const delivery = new AbortController();
+
+    await requestFetch({}, delivery.signal)(`${CARD_URL}/rpc`, { signal: sdk.signal });
+    delivery.abort();
+
+    expect(sentSignal(fetchMock).aborted).toBe(true);
+  });
+
+  it('aborts the request when the sdk aborts its own signal', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const sdk = new AbortController();
+    const delivery = new AbortController();
+
+    await requestFetch({}, delivery.signal)(`${CARD_URL}/rpc`, { signal: sdk.signal });
+    sdk.abort();
+
+    expect(sentSignal(fetchMock).aborted).toBe(true);
+  });
+
+  it('sends the delivery bound itself when the sdk sets no signal', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const delivery = new AbortController();
+
+    await requestFetch({}, delivery.signal)(`${CARD_URL}/rpc`, {});
+
+    expect(sentSignal(fetchMock)).toBe(delivery.signal);
+  });
+
+  it('leaves the sdk signal untouched when there is no delivery bound', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const sdk = new AbortController();
+
+    await requestFetch({})(`${CARD_URL}/rpc`, { signal: sdk.signal });
+
+    expect(sentSignal(fetchMock)).toBe(sdk.signal);
+  });
+
+  it('applies the per-server headers over the sdk headers', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await requestFetch({ authorization: 'Bearer sesame' })(`${CARD_URL}/rpc`, {
+      headers: { authorization: 'Bearer stale', 'content-type': 'application/json' },
+    });
+
+    expect(fetchMock.mock.calls[0]![1]!.headers).toEqual({
+      authorization: 'Bearer sesame',
+      'content-type': 'application/json',
+    });
   });
 });


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #186. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #186. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
