### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -80,18 +80,15 @@ describe('sdkClientFactory', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('resolves the card again for header sets a delimiter-joined key would collide', async () => {
+  it('resolves the card again for header sets that differ only in where the delimiter falls', async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => cardResponse());
     vi.stubGlobal('fetch', fetchMock);
 
     const create = sdkClientFactory();
-    await settled(create(CARD_URL, { a: '1', b: '2' }));
-    await settled(create(CARD_URL, { a: '1,b:2' }));
-    await settled(create(CARD_URL, { a: '1","b"],["x', b: '2' }));
+    await settled(create(CARD_URL, { authorization: 'Bearer sesame', 'x-api-key': 'tenant-a' }));
+    await settled(create(CARD_URL, { authorization: 'Bearer sesame,x-api-key:tenant-a' }));
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(fetchMock.mock.calls.map((call) => (call[1]?.headers as Record<string, string>).a))
-      .toEqual(['1', '1,b:2', '1","b"],["x']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('shares one card fetch across calls differing only in trace headers', async () => {

--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -80,6 +80,20 @@ describe('sdkClientFactory', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('resolves the card again for header sets a delimiter-joined key would collide', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => cardResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    await settled(create(CARD_URL, { a: '1', b: '2' }));
+    await settled(create(CARD_URL, { a: '1,b:2' }));
+    await settled(create(CARD_URL, { a: '1","b"],["x', b: '2' }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls.map((call) => (call[1]?.headers as Record<string, string>).a))
+      .toEqual(['1', '1,b:2', '1","b"],["x']);
+  });
+
   it('shares one card fetch across calls differing only in trace headers', async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => cardResponse());
     vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #187. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #187. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
