### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/.changeset/bound-agent-card-resolution.md
+++ b/.changeset/bound-agent-card-resolution.md
@@ -1,0 +1,5 @@
+---
+"@cycgraph/a2a": patch
+---
+
+Bound each shared Agent Card resolution with its own 30s timeout and evict the cache entry when it fires. A remote that accepted the connection and never answered previously left a permanently pending card promise cached for that agent, failing every later call to it until the process restarted.

--- a/packages/a2a/src/client.ts
+++ b/packages/a2a/src/client.ts
@@ -7,6 +7,7 @@
 import type { Client as SdkClient } from '@a2a-js/sdk/client';
 import type { A2AClient, A2ATaskResult } from '@cycgraph/orchestrator';
 import { sdkClientFactory, type CreateSdkClient } from './connection.js';
+import { raceAbort } from './race.js';
 import { isPending } from './task-state.js';
 import { toResult } from './translate.js';
 
@@ -43,9 +44,9 @@ export function createA2AClient(options: A2AClientOptions = {}): A2AClient {
     const signal = abortSignal ? AbortSignal.any([timeout.signal, abortSignal]) : timeout.signal;
 
     try {
-      const client = await raceAbort(create(agentCardUrl, headers, signal), signal);
+      const client = await raceDeliveryBound(create(agentCardUrl, headers, signal), signal);
       // Cast: the generated request type demands fields the server defaults.
-      const task = await raceAbort(client.sendMessage({ message } as never), signal);
+      const task = await raceDeliveryBound(client.sendMessage({ message } as never), signal);
       return toResult(await settle(client, task, deadline, signal));
     } catch (error) {
       // A rejection here means no task was ever observed (settle absorbs
@@ -88,22 +89,11 @@ export function createA2AClient(options: A2AClientOptions = {}): A2AClient {
 
 /**
  * Race a promise against the delivery signal, so an await cannot outlive
- * the budget even when the underlying SDK call ignores cancellation. The
- * losing promise is left to settle on its own; the point is that the NODE
- * observes the bound, not that the socket is guaranteed closed.
+ * the budget even when the underlying SDK call ignores cancellation.
  */
-function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (!signal.aborted) {
-    return new Promise<T>((resolve, reject) => {
-      const onAbort = () => reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'));
-      signal.addEventListener('abort', onAbort, { once: true });
-      promise.then(
-        (value) => { signal.removeEventListener('abort', onAbort); resolve(value); },
-        (error: unknown) => { signal.removeEventListener('abort', onAbort); reject(error as Error); },
-      );
-    });
-  }
-  return Promise.reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'));
+function raceDeliveryBound<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return raceAbort(promise, signal, () =>
+    signal.reason instanceof Error ? signal.reason : new Error('aborted'));
 }
 
 /**
@@ -155,7 +145,7 @@ async function settle(
       return task;
     }
     try {
-      task = await raceAbort(client.getTask({ name: `tasks/${task.id}` } as never), signal);
+      task = await raceDeliveryBound(client.getTask({ name: `tasks/${task.id}` } as never), signal);
     } catch (error) {
       // The bound fired while a poll was in flight: the last observed task
       // is still the honest answer. A non-abort rejection is a real

--- a/packages/a2a/src/connection.ts
+++ b/packages/a2a/src/connection.ts
@@ -15,6 +15,7 @@
 import { ClientFactory, DefaultAgentCardResolver, JsonRpcTransportFactory } from '@a2a-js/sdk/client';
 import type { Client as SdkClient } from '@a2a-js/sdk/client';
 import { isPrivateOrLoopbackHost } from '@cycgraph/orchestrator';
+import { raceAbort } from './race.js';
 
 /**
  * Builds the SDK client one call runs against. Injectable for tests.
@@ -119,25 +120,6 @@ export function requestFetch(headers: Record<string, string>, signal?: AbortSign
  */
 const CARD_TIMEOUT_MS = 30_000;
 
-/**
- * Settle with `promise`, or reject once `signal` aborts — whichever comes
- * first. The shared card promise MUST settle even when the underlying
- * fetch ignores its abort, because settling is what evicts the cache
- * entry; a forever-pending entry would fail every later call to that key.
- */
-function raceCardTimeout<T>(promise: Promise<T>, signal: AbortSignal, timeoutMs: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(
-      new Error(`agent card resolution did not complete within the ${timeoutMs}ms budget`,
-        { cause: signal.reason }));
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(
-      (value) => { signal.removeEventListener('abort', onAbort); resolve(value); },
-      (error: unknown) => { signal.removeEventListener('abort', onAbort); reject(error as Error); },
-    );
-  });
-}
-
 /** Options for {@link sdkClientFactory}. */
 export interface SdkClientFactoryOptions {
   /** Ceiling on one shared card resolution. Defaults to 30s. */
@@ -161,17 +143,21 @@ export function sdkClientFactory(options: SdkClientFactoryOptions = {}): CreateS
       // The promise is cached, so concurrent first calls share one fetch.
       // It carries the caller's headers but not its signal: a shared
       // promise must not be rejected for everyone by one caller's abort.
-      // deliver() still bounds the caller itself via raceAbort.
+      // deliver() still bounds the caller itself against its own signal.
       //
       // Its own timeout replaces that missing signal: a remote that
       // accepts the connection and never answers would otherwise leave a
       // pending promise cached at this key for the life of the process.
       const cardTimeout = AbortSignal.timeout(cardTimeoutMs);
       const cardFetch = requestFetch(headers, cardTimeout);
-      const resolving = raceCardTimeout(
+      // The race is what guarantees the promise settles even if the fetch
+      // ignores its abort, and settling is what evicts the cache entry.
+      const resolving = raceAbort(
         new DefaultAgentCardResolver({ fetchImpl: cardFetch }).resolve(agentCardUrl, ''),
         cardTimeout,
-        cardTimeoutMs,
+        () => new Error(
+          `agent card resolution did not complete within the ${cardTimeoutMs}ms budget`,
+          { cause: cardTimeout.reason }),
       );
       cards.set(key, resolving);
       resolving.catch(() => {

--- a/packages/a2a/src/connection.ts
+++ b/packages/a2a/src/connection.ts
@@ -5,8 +5,9 @@
  * per call; caching one would freeze the first caller's headers into every
  * later request. The Agent Card is cached per URL AND header set, fetched
  * with the same per-server headers as every other request (a registry
- * entry's auth gate covers its card endpoint too), and a failed resolution
- * is evicted so a transient fault never outlives the request that hit it.
+ * entry's auth gate covers its card endpoint too), and a resolution that
+ * fails or outruns its own timeout is evicted so a transient fault never
+ * outlives the request that hit it.
  *
  * @module connection
  */
@@ -113,10 +114,42 @@ export function requestFetch(headers: Record<string, string>, signal?: AbortSign
 }
 
 /**
+ * Ceiling on one shared Agent Card resolution, independent of any single
+ * caller's deadline.
+ */
+const CARD_TIMEOUT_MS = 30_000;
+
+/**
+ * Settle with `promise`, or reject once `signal` aborts — whichever comes
+ * first. The shared card promise MUST settle even when the underlying
+ * fetch ignores its abort, because settling is what evicts the cache
+ * entry; a forever-pending entry would fail every later call to that key.
+ */
+function raceCardTimeout<T>(promise: Promise<T>, signal: AbortSignal, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(
+      new Error(`agent card resolution did not complete within the ${timeoutMs}ms budget`,
+        { cause: signal.reason }));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => { signal.removeEventListener('abort', onAbort); resolve(value); },
+      (error: unknown) => { signal.removeEventListener('abort', onAbort); reject(error as Error); },
+    );
+  });
+}
+
+/** Options for {@link sdkClientFactory}. */
+export interface SdkClientFactoryOptions {
+  /** Ceiling on one shared card resolution. Defaults to 30s. */
+  cardTimeoutMs?: number;
+}
+
+/**
  * Default {@link CreateSdkClient}, with an Agent Card cache scoped to this
  * factory and keyed by URL plus the headers the card was fetched with.
  */
-export function sdkClientFactory(): CreateSdkClient {
+export function sdkClientFactory(options: SdkClientFactoryOptions = {}): CreateSdkClient {
+  const cardTimeoutMs = options.cardTimeoutMs ?? CARD_TIMEOUT_MS;
   const cards = new Map<string, Promise<unknown>>();
 
   return async (agentCardUrl, headers, signal) => {
@@ -129,9 +162,17 @@ export function sdkClientFactory(): CreateSdkClient {
       // It carries the caller's headers but not its signal: a shared
       // promise must not be rejected for everyone by one caller's abort.
       // deliver() still bounds the caller itself via raceAbort.
-      const cardFetch = requestFetch(headers);
-      const resolving = new DefaultAgentCardResolver({ fetchImpl: cardFetch })
-        .resolve(agentCardUrl, '');
+      //
+      // Its own timeout replaces that missing signal: a remote that
+      // accepts the connection and never answers would otherwise leave a
+      // pending promise cached at this key for the life of the process.
+      const cardTimeout = AbortSignal.timeout(cardTimeoutMs);
+      const cardFetch = requestFetch(headers, cardTimeout);
+      const resolving = raceCardTimeout(
+        new DefaultAgentCardResolver({ fetchImpl: cardFetch }).resolve(agentCardUrl, ''),
+        cardTimeout,
+        cardTimeoutMs,
+      );
       cards.set(key, resolving);
       resolving.catch(() => {
         if (cards.get(key) === resolving) cards.delete(key);

--- a/packages/a2a/src/race.ts
+++ b/packages/a2a/src/race.ts
@@ -1,0 +1,32 @@
+/**
+ * Abort-race primitive shared by the delivery bound and the Agent Card
+ * timeout.
+ *
+ * @module race
+ */
+
+/**
+ * Settle with `promise`, or reject with `rejection()` once `signal`
+ * aborts — whichever comes first. An already-aborted signal rejects
+ * without subscribing.
+ *
+ * The awaited promise MUST be able to settle even when the underlying
+ * call ignores cancellation: the loser is left to settle on its own, so
+ * the point is that the CALLER observes the bound, not that the socket is
+ * closed.
+ */
+export function raceAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  rejection: () => Error,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(rejection());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(rejection());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => { signal.removeEventListener('abort', onAbort); resolve(value); },
+      (error: unknown) => { signal.removeEventListener('abort', onAbort); reject(error as Error); },
+    );
+  });
+}

--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -131,6 +131,27 @@ describe('sdkClientFactory', () => {
     await expect(create(CARD_URL, {})).rejects.toThrow('must use http(s)');
   });
 
+  it('rejects card resolution that outruns the card timeout', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => undefined)));
+
+    const create = sdkClientFactory({ cardTimeoutMs: 5 });
+
+    await expect(create(CARD_URL, {})).rejects.toThrow('agent card resolution did not complete within the 5ms budget');
+  });
+
+  it('retries card resolution after a fetch that never settles', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => new Promise<Response>(() => undefined))
+      .mockImplementation(async () => cardResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory({ cardTimeoutMs: 5 });
+    await expect(create(CARD_URL, {})).rejects.toThrow('budget');
+    await settled(create(CARD_URL, {}));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('retries card resolution after a failure instead of caching the rejection', async () => {
     const fetchMock = vi.fn()
       .mockRejectedValueOnce(new Error('connection refused'))

--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -146,7 +146,8 @@ describe('sdkClientFactory', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const create = sdkClientFactory({ cardTimeoutMs: 5 });
-    await expect(create(CARD_URL, {})).rejects.toThrow('budget');
+    await expect(create(CARD_URL, {}))
+      .rejects.toThrow('agent card resolution did not complete within the 5ms budget');
     await settled(create(CARD_URL, {}));
 
     expect(fetchMock).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #193. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #193. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
