### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -8,7 +8,7 @@ import { requestFetch, sdkClientFactory } from '../src/connection.js';
 
 const CARD_URL = 'http://agent.example';
 
-function cardResponse(endpointUrl = `${CARD_URL}/rpc`): Response {
+function cardResponse(endpointUrl = `${CARD_URL}/rpc`, extra: Record<string, unknown> = {}): Response {
   return new Response(JSON.stringify({
     name: 'scenario',
     description: '',
@@ -20,6 +20,7 @@ function cardResponse(endpointUrl = `${CARD_URL}/rpc`): Response {
     defaultInputModes: ['text/plain'],
     defaultOutputModes: ['text/plain'],
     skills: [],
+    ...extra,
   }), { status: 200, headers: { 'content-type': 'application/json' } });
 }
 
@@ -129,6 +130,58 @@ describe('sdkClientFactory', () => {
     const create = sdkClientFactory();
 
     await expect(create(CARD_URL, {})).rejects.toThrow('must use http(s)');
+  });
+
+  it('refuses a card whose supported interface points at a private host', async () => {
+    const fetchMock = vi.fn(async () => cardResponse(`${CARD_URL}/rpc`, {
+      supportedInterfaces: [{ url: 'http://169.254.169.254/latest/meta-data', transport: 'JSONRPC' }],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+
+    await expect(create(CARD_URL, {}))
+      .rejects.toThrow('agent card endpoint "http://169.254.169.254/latest/meta-data" points at a private/loopback host');
+  });
+
+  it('refuses a card whose additional interface points at a private host', async () => {
+    const fetchMock = vi.fn(async () => cardResponse(`${CARD_URL}/rpc`, {
+      additionalInterfaces: [{ url: 'http://10.0.0.5/rpc', transport: 'JSONRPC' }],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+
+    await expect(create(CARD_URL, {}))
+      .rejects.toThrow('agent card endpoint "http://10.0.0.5/rpc" points at a private/loopback host');
+  });
+
+  it('refuses a card whose additional interface is not http(s)', async () => {
+    const fetchMock = vi.fn(async () => cardResponse(`${CARD_URL}/rpc`, {
+      additionalInterfaces: [{ url: 'file:///etc/passwd', transport: 'JSONRPC' }],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+
+    await expect(create(CARD_URL, {})).rejects.toThrow('must use http(s)');
+  });
+
+  it('accepts a card whose secondary endpoints are all public', async () => {
+    const fetchMock = vi.fn(async () => cardResponse(`${CARD_URL}/rpc`, {
+      supportedInterfaces: [
+        { url: 'https://agent.example/jsonrpc', protocolBinding: 'JSONRPC', protocolVersion: '1.0', tenant: '' },
+      ],
+      additionalInterfaces: [
+        { url: 'https://agent.example/extra', protocolBinding: 'JSONRPC', protocolVersion: '1.0', tenant: '' },
+      ],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    const client = await create(CARD_URL, {});
+
+    expect(typeof client.sendMessage).toBe('function');
   });
 
   it('rejects card resolution that outruns the card timeout', async () => {


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #194. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #194. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
