### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/ops/maintenance/README.md
+++ b/ops/maintenance/README.md
@@ -53,7 +53,10 @@ refuses to file rather than filing blind. For `issue-fix`:
 `--label <name>` (which label counts as approval), `--issueNumber n`
 (fix a specific issue), and `--key <finding-key>` (detached mode: fix a
 named finding without reading or closing any issue — how the cycle runs
-without GitHub). For `opt-propose`: `--target <bench filter>`,
+without GitHub). An `audit:` key names a finding whose whole
+specification is its issue text, so detached mode also needs
+`--ticketFile <path>` carrying that body; without it the run refuses
+rather than briefing the fixer with an empty spec. For `opt-propose`: `--target <bench filter>`,
 `--minImprovement n` (percent a proposal must measure, beyond the two
 runs' combined error margins), `--scope <dir>` (changes outside it are
 refused), `--attempts n`. For `feat-propose`: `--focus <area>` steers

--- a/ops/maintenance/src/audit-findings.ts
+++ b/ops/maintenance/src/audit-findings.ts
@@ -46,6 +46,17 @@ export function auditKey(title: string): string {
   return `audit:${normalized}`;
 }
 
+/**
+ * The title an audit issue body carries: its first markdown heading
+ * (`#` through `######`, with text after it), falling back to the
+ * finding key. Bodies filed by the audit workflow carry no heading, so
+ * the fallback is the ordinary path for a real ticket.
+ */
+export function auditTitle(body: string, key: string): string {
+  const heading = body.split('\n').find((line) => /^#{1,6}\s+\S/.test(line));
+  return heading !== undefined ? heading.replace(/^#{1,6}\s+/, '').trim() : key;
+}
+
 const SECTION_HEADS = /^(SEVERITY|EVIDENCE|DETAIL|SUGGESTION):/;
 
 /**

--- a/ops/maintenance/src/index.ts
+++ b/ops/maintenance/src/index.ts
@@ -23,7 +23,7 @@ export { issueFix } from './issue-fix.js';
 export { optPropose } from './opt-workflow.js';
 export { featPropose } from './feat-propose.js';
 export { charterOrder, repoAudit } from './audit-workflow.js';
-export { auditKey, parseAuditFindings, siftAuditFindings, AUDIT_SEVERITIES } from './audit-findings.js';
+export { auditKey, auditTitle, parseAuditFindings, siftAuditFindings, AUDIT_SEVERITIES } from './audit-findings.js';
 export type { AuditFinding, AuditSeverity, AuditSiftOptions, AuditSiftResult } from './audit-findings.js';
 export { optApply } from './opt-apply.js';
 export { prRevise } from './pr-revise.js';
@@ -35,7 +35,7 @@ export { extractTicketDiff, parseProposal, pathTokens, proposalKey, safeAcceptan
 export type { FeatureProposal } from './proposal.js';
 export { compareBench, parseBenchJson, runAliasedBench } from './bench.js';
 export type { BenchComparison, BenchDelta, BenchRow } from './bench.js';
-export { commentOnlyChange, eslintDisableCount, judgeIssueFix, parseIssueFinding, testCount } from './issue-judge.js';
+export { commentOnlyChange, eslintDisableCount, findingFromKey, judgeIssueFix, parseIssueFinding, testCount } from './issue-judge.js';
 export type { IssueFinding, IssueFixEvidence, IssueFixVerdict } from './issue-judge.js';
 export { resolveRepo } from './repo.js';
 export type { MaintenanceBuild, MaintenanceEnv, MaintenanceWorkflow } from './types.js';

--- a/ops/maintenance/src/issue-fix.ts
+++ b/ops/maintenance/src/issue-fix.ts
@@ -38,7 +38,8 @@ import {
   searchTool,
 } from '@cycgraph/tools/workspace';
 import { scanCore, type CoreFinding } from './core-scan.js';
-import { judgeAuditFix, judgeIssueFix, parseIssueFinding, type IssueFinding } from './issue-judge.js';
+import { auditTitle } from './audit-findings.js';
+import { findingFromKey, judgeAuditFix, judgeIssueFix, parseIssueFinding, type IssueFinding } from './issue-judge.js';
 import { checksEnv, CHANGESET_INSTRUCTION, STANDARDS_BRIEF, resolveRepo } from './repo.js';
 import { LESSON_TAG } from './memory.js';
 import type { MaintenanceEnv, MaintenanceWorkflow } from './types.js';
@@ -75,14 +76,6 @@ const GUIDANCE: Record<CoreFinding['kind'], string> = {
   'skipped-test': 'Remove the .skip so the test runs, and make it pass by fixing whatever it exercises. Deleting the test will be refused.',
   'lint-warning': 'Fix the code the warning points at. Adding an eslint-disable comment or touching lint configuration will be refused.',
 };
-
-const AUDIT_PREFIX = 'audit:';
-
-/** The first markdown heading of an audit issue body, or the key when it has none. */
-function auditTitle(body: string, key: string): string {
-  const heading = body.split('\n').find((line) => /^#{1,6}\s+\S/.test(line));
-  return heading !== undefined ? heading.replace(/^#{1,6}\s+/, '').trim() : key;
-}
 
 const AUDIT_GUIDANCE = [
   'This finding came from a model-driven audit: the issue text above is the whole specification.',
@@ -162,14 +155,19 @@ export function issueFix(): MaintenanceWorkflow<typeof params> {
             };
           }
           if (p.key !== '') {
+            const finding = findingFromKey(p.key);
+            if (finding === undefined) {
+              return {
+                has_work: false,
+                detail: `'${p.key}' is not a finding key ('<kind>:<file>:<detail>' or 'audit:<title-slug>')`,
+              };
+            }
             // `audit:<title-slug>` carries no file component and no
             // specification: an audit finding's evidence, detail and
             // suggestion live only in its issue text, so detached mode
             // needs that body handed in rather than guessed from the key.
-            if (p.key.startsWith(AUDIT_PREFIX)) {
-              const body = p.ticketFile !== ''
-                ? await readFile(p.ticketFile, 'utf8').catch(() => '')
-                : '';
+            if (finding.kind === 'audit') {
+              const body = p.ticketFile !== '' ? await readFile(p.ticketFile, 'utf8') : '';
               if (body.trim() === '') {
                 return {
                   has_work: false,
@@ -179,22 +177,12 @@ export function issueFix(): MaintenanceWorkflow<typeof params> {
               return {
                 has_work: true,
                 detached: true,
-                key: p.key,
-                kind: 'audit',
-                file: '',
+                ...finding,
                 issue_title: auditTitle(body, p.key),
                 issue_body: body.slice(0, 12_000),
               };
             }
-            const kind = p.key.slice(0, p.key.indexOf(':'));
-            const file = p.key.slice(p.key.indexOf(':') + 1, p.key.lastIndexOf(':'));
-            if (file === '') {
-              return {
-                has_work: false,
-                detail: `'${p.key}' is not a core-scan finding key ('<kind>:<file>:<detail>')`,
-              };
-            }
-            return { has_work: true, detached: true, key: p.key, kind, file };
+            return { has_work: true, detached: true, ...finding };
           }
           return { has_work: false, detail: 'cannot read the issue ledger and no --key was given' };
         },

--- a/ops/maintenance/src/issue-fix.ts
+++ b/ops/maintenance/src/issue-fix.ts
@@ -14,7 +14,9 @@
  *
  * With no readable ledger, `--key` runs the same cycle detached — the
  * finding named directly, nothing closed — which is what makes the
- * loop testable without GitHub.
+ * loop testable without GitHub. An `audit:` key carries no file and no
+ * specification, so detached mode pairs it with `--ticketFile`, whose
+ * contents are the finding's issue text.
  *
  * @module maintenance/issue-fix
  */
@@ -50,6 +52,8 @@ const params = z.object({
     .describe('Fix this specific issue. Zero picks the oldest approved one'),
   key: z.string().default('')
     .describe('Detached mode: fix this finding key directly, without reading or closing any issue'),
+  ticketFile: z.string().default('')
+    .describe('The issue body backing a detached --key, read from this file. Required for `audit:` keys'),
   checks: z.array(z.string()).default([])
     .describe('Commands that must pass before a fix may be committed, e.g. ["npm run lint"]'),
   lint: z.boolean().default(true)
@@ -71,6 +75,14 @@ const GUIDANCE: Record<CoreFinding['kind'], string> = {
   'skipped-test': 'Remove the .skip so the test runs, and make it pass by fixing whatever it exercises. Deleting the test will be refused.',
   'lint-warning': 'Fix the code the warning points at. Adding an eslint-disable comment or touching lint configuration will be refused.',
 };
+
+const AUDIT_PREFIX = 'audit:';
+
+/** The first markdown heading of an audit issue body, or the key when it has none. */
+function auditTitle(body: string, key: string): string {
+  const heading = body.split('\n').find((line) => /^#{1,6}\s+\S/.test(line));
+  return heading !== undefined ? heading.replace(/^#{1,6}\s+/, '').trim() : key;
+}
 
 const AUDIT_GUIDANCE = [
   'This finding came from a model-driven audit: the issue text above is the whole specification.',
@@ -150,8 +162,38 @@ export function issueFix(): MaintenanceWorkflow<typeof params> {
             };
           }
           if (p.key !== '') {
+            // `audit:<title-slug>` carries no file component and no
+            // specification: an audit finding's evidence, detail and
+            // suggestion live only in its issue text, so detached mode
+            // needs that body handed in rather than guessed from the key.
+            if (p.key.startsWith(AUDIT_PREFIX)) {
+              const body = p.ticketFile !== ''
+                ? await readFile(p.ticketFile, 'utf8').catch(() => '')
+                : '';
+              if (body.trim() === '') {
+                return {
+                  has_work: false,
+                  detail: `'${p.key}' is an audit finding: its specification is the issue text, so detached mode needs --ticketFile carrying that body — the key alone is insufficient`,
+                };
+              }
+              return {
+                has_work: true,
+                detached: true,
+                key: p.key,
+                kind: 'audit',
+                file: '',
+                issue_title: auditTitle(body, p.key),
+                issue_body: body.slice(0, 12_000),
+              };
+            }
             const kind = p.key.slice(0, p.key.indexOf(':'));
             const file = p.key.slice(p.key.indexOf(':') + 1, p.key.lastIndexOf(':'));
+            if (file === '') {
+              return {
+                has_work: false,
+                detail: `'${p.key}' is not a core-scan finding key ('<kind>:<file>:<detail>')`,
+              };
+            }
             return { has_work: true, detached: true, key: p.key, kind, file };
           }
           return { has_work: false, detail: 'cannot read the issue ledger and no --key was given' };
@@ -168,6 +210,17 @@ export function issueFix(): MaintenanceWorkflow<typeof params> {
             { key?: string; kind?: string; issue_number?: number; issue_title?: string; issue_body?: string } | undefined;
           const findings = await scanCore(workspaceAt, { lint: p.lint });
           if (pick?.kind === 'audit') {
+            const spec = pick.issue_body ?? '';
+            // The audit finding's issue text IS the specification; with
+            // none of it there is nothing to brief the fixer with, so
+            // the run exits visibly rather than fixing an empty spec.
+            if (spec.trim() === '') {
+              return {
+                has_target: false,
+                keys: findings.map((f) => f.key),
+                detail: `'${pick.key ?? ''}' is an audit finding whose issue text did not reach the scan — its specification cannot be reconstructed from the key`,
+              };
+            }
             return {
               has_target: true,
               audit: true,
@@ -175,7 +228,7 @@ export function issueFix(): MaintenanceWorkflow<typeof params> {
               instruction: [
                 `Resolve the audited finding this approved issue describes.`,
                 `# ${pick.issue_title ?? pick.key ?? ''}`,
-                pick.issue_body ?? '',
+                spec,
                 AUDIT_GUIDANCE,
                 'Change nothing unrelated.',
               ].join('\n'),

--- a/ops/maintenance/src/issue-judge.ts
+++ b/ops/maintenance/src/issue-judge.ts
@@ -22,19 +22,32 @@ export interface IssueFinding {
 
 const KINDS: readonly CoreFinding['kind'][] = ['todo', 'skipped-test', 'lint-warning'];
 
+/**
+ * Recover the finding a marker key names, or `undefined` when the key is
+ * not one of ours.
+ *
+ * Audit keys are `audit:<title-slug>` — no file component, since the
+ * issue body itself carries the finding's evidence and location. Every
+ * other key is `<kind>:<file>:<detail>` over a known scan kind.
+ */
+export function findingFromKey(key: string): IssueFinding | undefined {
+  if (key.startsWith('audit:')) {
+    return key.length > 'audit:'.length ? { key, kind: 'audit', file: '' } : undefined;
+  }
+  const split = key.indexOf(':');
+  if (split === -1) return undefined;
+  const kind = key.slice(0, split);
+  const file = key.slice(split + 1, key.lastIndexOf(':'));
+  if (!(KINDS as readonly string[]).includes(kind) || file === '') return undefined;
+  return { key, kind: kind as CoreFinding['kind'], file };
+}
+
 /** Recover the finding a filed issue carries, or `undefined` when it carries none. */
 export function parseIssueFinding(body: string): IssueFinding | undefined {
   const keys = issueMarkers([{ number: 0, title: '', body } satisfies IssueRef]);
   const key = [...keys][0];
   if (key === undefined) return undefined;
-  // Audit keys are `audit:<title-slug>` — no file component; the issue
-  // body itself carries the finding's evidence and location.
-  if (key.startsWith('audit:') && key.length > 'audit:'.length) {
-    return { key, kind: 'audit', file: '' };
-  }
-  const [kind, file] = [key.slice(0, key.indexOf(':')), key.slice(key.indexOf(':') + 1, key.lastIndexOf(':'))];
-  if (!(KINDS as readonly string[]).includes(kind) || file === '') return undefined;
-  return { key, kind: kind as CoreFinding['kind'], file };
+  return findingFromKey(key);
 }
 
 const COMMENT_LINE = /^[+-]\s*(\/\/|\/\*|\*|\*\/)?\s*$|^[+-]\s*(\/\/|\/\*|\*)/;

--- a/ops/maintenance/test/audit-findings.test.ts
+++ b/ops/maintenance/test/audit-findings.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { auditKey, parseAuditFindings, siftAuditFindings } from '../src/audit-findings.js';
+import { auditKey, auditTitle, parseAuditFindings, siftAuditFindings } from '../src/audit-findings.js';
 import { charterOrder } from '../src/audit-workflow.js';
 
 const WELL_FORMED = [
@@ -82,6 +82,32 @@ describe('auditKey', () => {
 
   it('is namespaced apart from feature keys', () => {
     expect(auditKey('anything')).toMatch(/^audit:/);
+  });
+});
+
+describe('auditTitle', () => {
+  it('takes the first markdown heading of the body', () => {
+    const body = ['Preamble line.', '### Retriever drops fact ids', 'SEVERITY: high'].join('\n');
+
+    expect(auditTitle(body, 'audit:retriever-drops-fact-ids')).toBe('Retriever drops fact ids');
+  });
+
+  it('falls back to the key for a body with no heading', () => {
+    const body = ['SEVERITY: high', 'EVIDENCE:', 'a/b.ts shows it.', 'DETAIL:', 'It drops ids.'].join('\n');
+
+    expect(auditTitle(body, 'audit:retriever-drops-fact-ids')).toBe('audit:retriever-drops-fact-ids');
+  });
+
+  it('does not take a heading deeper than six hashes', () => {
+    const body = '####### Too deep to be a heading';
+
+    expect(auditTitle(body, 'audit:key')).toBe('audit:key');
+  });
+
+  it('does not take a heading with no text after it', () => {
+    const body = ['###', 'SEVERITY: low'].join('\n');
+
+    expect(auditTitle(body, 'audit:key')).toBe('audit:key');
   });
 });
 


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #199. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #199. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
