### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/ops/maintenance/test/repo.test.ts
+++ b/ops/maintenance/test/repo.test.ts
@@ -1,10 +1,11 @@
 /**
  * Tests for the repository helpers (src/repo.ts) — chiefly the
- * credential scrub every workflow spawn site relies on.
+ * credential scrub every workflow spawn site relies on and the mention
+ * strip that keeps relayed agent prose from dispatching workflows.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { checksEnv } from '../src/repo.js';
+import { WORKFLOW_MENTION, checksEnv, stripMentions } from '../src/repo.js';
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -39,5 +40,49 @@ describe('checksEnv', () => {
     checksEnv();
 
     expect(process.env['DATABASE_URL']).toBe('postgres://localhost:5432/app');
+  });
+});
+
+describe('stripMentions', () => {
+  it('neutralizes the workflow mention', () => {
+    const relayed = stripMentions(`please ${WORKFLOW_MENTION} take another look`);
+
+    expect(relayed).toBe('please cycgraph take another look');
+  });
+
+  it('neutralizes the mention regardless of case', () => {
+    const relayed = stripMentions('@CycGraph and @CYCGRAPH and @cycgraph');
+
+    expect(relayed).toBe('cycgraph and cycgraph and cycgraph');
+  });
+
+  it('neutralizes every occurrence in the text', () => {
+    const relayed = stripMentions('@cycgraph @cycgraph @cycgraph');
+
+    expect(relayed).toBe('cycgraph cycgraph cycgraph');
+  });
+
+  it('neutralizes the mention when punctuation follows it', () => {
+    const relayed = stripMentions('@cycgraph: revise, then @cycgraph-bot, then @cycgraph.');
+
+    expect(relayed).toBe('cycgraph: revise, then cycgraph-bot, then cycgraph.');
+  });
+
+  it('neutralizes the mention when it is embedded in surrounding text', () => {
+    const relayed = stripMentions('quoted from the PR body: "ping@cycgraph"');
+
+    expect(relayed).toBe('quoted from the PR body: "pingcycgraph"');
+  });
+
+  it('leaves text without the mention unchanged', () => {
+    const relayed = stripMentions('cycgraph reviewed the diff and @other was mentioned');
+
+    expect(relayed).toBe('cycgraph reviewed the diff and @other was mentioned');
+  });
+
+  it('returns empty text unchanged', () => {
+    const relayed = stripMentions('');
+
+    expect(relayed).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #200. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #200. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
