### PR TITLE
chore: resolve owed upkeep

### DIFF
--- a/.changeset/a2a-allowlist-fails-closed.md
+++ b/.changeset/a2a-allowlist-fails-closed.md
@@ -1,0 +1,5 @@
+---
+"@cycgraph/orchestrator": patch
+---
+
+The `a2a` node now denies access when a server's `allowed_agents` list is non-empty and the node declares no `agent_id`, matching the MCP allowlist behavior. Previously omitting `agent_id` bypassed the allowlist entirely; graphs that relied on that must now set `agent_id` on restricted `a2a` nodes.

--- a/packages/orchestrator/src/execution/nodes/a2a.ts
+++ b/packages/orchestrator/src/execution/nodes/a2a.ts
@@ -84,13 +84,17 @@ export async function executeA2ANode(
     throw new NodeConfigError(node.id, 'a2a', `a2a server "${config.server_id}"`);
   }
 
-  // Server allowlist: only listed agents may use this server.
-  if (server.allowed_agents && node.agent_id && !server.allowed_agents.includes(node.agent_id)) {
-    throw new NodeConfigError(
-      node.id,
-      'a2a',
-      `agent "${node.agent_id}" permitted to use a2a server "${config.server_id}"`,
-    );
+  // Server allowlist: only listed agents may use this server. `agent_id` is
+  // optional on a node, so a missing identity fails closed — otherwise omitting
+  // it would bypass the restriction entirely.
+  if (server.allowed_agents && server.allowed_agents.length > 0) {
+    if (!node.agent_id || !server.allowed_agents.includes(node.agent_id)) {
+      throw new NodeConfigError(
+        node.id,
+        'a2a',
+        `agent "${node.agent_id ?? 'unknown'}" permitted to use a2a server "${config.server_id}"`,
+      );
+    }
   }
 
   logger.info('a2a_executing', {

--- a/packages/orchestrator/test/a2a-node.test.ts
+++ b/packages/orchestrator/test/a2a-node.test.ts
@@ -196,6 +196,28 @@ describe('executeA2ANode', () => {
       .rejects.toThrow(/permitted to use/);
   });
 
+  it('refuses a node with no agent_id when the server has an allowlist', async () => {
+    const registry = await registryWith({ allowedAgents: ['approved-agent'] });
+    const anonymous = node();
+
+    await expect(executeA2ANode(anonymous, stateView(), 1, await ctxWith(fakeClient({}), registry)))
+      .rejects.toThrow(/permitted to use/);
+  });
+
+  it('allows a node with no agent_id when the server has no allowlist', async () => {
+    const registry = await registryWith({ allowedAgents: [] });
+    const anonymous = node();
+
+    const action = await executeA2ANode(
+      anonymous,
+      stateView(),
+      1,
+      await ctxWith(fakeClient({ artifacts: [{ name: 'report', value: 'ok' }] }), registry),
+    );
+
+    expect((action.payload as any).updates.findings).toBe('ok');
+  });
+
 });
 
 describe('executeA2ANode — per-server concurrency cap', () => {


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #210. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #210. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
