### PR TITLE
fix: Agent Card endpoint SSRF guard has no DNS-rebinding re-check

### DIFF
--- a/.changeset/a2a-endpoint-dns-rebinding-recheck.md
+++ b/.changeset/a2a-endpoint-dns-rebinding-recheck.md
@@ -1,0 +1,5 @@
+---
+"@cycgraph/a2a": patch
+---
+
+The Agent Card endpoint SSRF guard now re-checks DNS-resolved addresses at connect time, so a card advertising a public-looking hostname that resolves to loopback, link-local, cloud-metadata, or RFC1918 addresses is refused instead of being connected to. Lookups fail closed (5s budget) and the `CYCGRAPH_ALLOW_PRIVATE_A2A_URLS=true` development opt-out still skips the whole guard.

--- a/packages/a2a/src/connection.ts
+++ b/packages/a2a/src/connection.ts
@@ -12,10 +12,9 @@
  * @module connection
  */
 
-import { lookup as dnsLookup } from 'node:dns/promises';
 import { ClientFactory, DefaultAgentCardResolver, JsonRpcTransportFactory } from '@a2a-js/sdk/client';
 import type { Client as SdkClient } from '@a2a-js/sdk/client';
-import { isPrivateOrLoopbackHost } from '@cycgraph/orchestrator';
+import { assertResolvedHostPublic, isPrivateOrLoopbackHost } from '@cycgraph/orchestrator';
 import { raceAbort } from './race.js';
 
 /**
@@ -65,53 +64,8 @@ function endpointUrls(card: unknown): string[] {
   return urls.filter((value): value is string => typeof value === 'string' && value !== '');
 }
 
-/** Max time spent resolving one endpoint host before the guard fails closed. */
-const DNS_LOOKUP_TIMEOUT_MS = 5000;
-
-/**
- * Connect-time DNS re-check for one card endpoint host. The literal-hostname
- * test above only sees the string the remote advertised: a public-looking
- * name whose record points at `127.0.0.1`, `169.254.169.254`, or an RFC1918
- * address passes it, and the SDK's own `fetch` then resolves that name and
- * connects to the private address (DNS rebinding). Resolving here and
- * rejecting if ANY returned address is private closes the static case.
- *
- * Fails closed: a lookup that errors or outruns its budget blocks the
- * endpoint rather than letting the transport connect unvalidated. A TTL-0
- * attacker who flips the record between this lookup and the SDK's connect
- * is a documented residual — pair with network egress policy for that.
- */
-async function assertEndpointResolvesPublic(parsed: URL, value: string): Promise<void> {
-  // URL.hostname keeps IPv6 in brackets; dns.lookup wants the bare address.
-  const host = parsed.hostname.replace(/^\[|\]$/g, '');
-  // Literal IPs were fully decided by isPrivateOrLoopbackHost — nothing to resolve.
-  if (/^[0-9.]+$/.test(host) || host.includes(':')) return;
-
-  let addresses: Array<{ address: string }>;
-  try {
-    const timeout = new Promise<never>((_, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error(`lookup timed out after ${DNS_LOOKUP_TIMEOUT_MS}ms`)),
-        DNS_LOOKUP_TIMEOUT_MS);
-      // A pending guard must not hold the process open.
-      (timer as { unref?: () => void }).unref?.();
-    });
-    addresses = await Promise.race([dnsLookup(host, { all: true, verbatim: true }), timeout]);
-  } catch (error) {
-    throw new Error(
-      `agent card endpoint "${value}" host "${host}" could not be resolved for SSRF validation: `
-      + `${(error as Error).message}`,
-      { cause: error });
-  }
-
-  const blocked = addresses.filter((entry) => isPrivateOrLoopbackHost(entry.address));
-  if (blocked.length > 0) {
-    throw new Error(
-      `agent card endpoint "${value}" resolves to a private/loopback address `
-      + `(${blocked.map((entry) => entry.address).join(', ')}) and is blocked (SSRF guard). `
-      + 'Set CYCGRAPH_ALLOW_PRIVATE_A2A_URLS=true to allow it in development.');
-  }
-}
+/** Env var opting one deployment out of both A2A URL guards. */
+const ALLOW_PRIVATE_ENV = 'CYCGRAPH_ALLOW_PRIVATE_A2A_URLS';
 
 /**
  * SSRF guard over the endpoints a resolved Agent Card offers. The
@@ -122,9 +76,18 @@ async function assertEndpointResolvesPublic(parsed: URL, value: string): Promise
  * DNS-resolved addresses, so a public name pointing at a private address
  * is refused too. Honors the card-url guard's opt-out: one protocol, one
  * decision.
+ *
+ * The card is remote-controlled, so the DNS half runs as ONE bounded
+ * step: hosts are deduped and resolved concurrently, and `signal` — the
+ * caller's own deadline — rejects the whole guard rather than letting a
+ * card that advertises N slow-resolving interfaces stall the call for N
+ * lookup budgets.
  */
-async function assertPublicEndpoints(card: unknown): Promise<void> {
-  if (process.env['CYCGRAPH_ALLOW_PRIVATE_A2A_URLS'] === 'true') return;
+async function assertPublicEndpoints(card: unknown, signal?: AbortSignal): Promise<void> {
+  if (process.env[ALLOW_PRIVATE_ENV] === 'true') return;
+  // Host → the first endpoint that advertised it, so one lookup answers
+  // for every endpoint sharing a host and the message still names one.
+  const hosts = new Map<string, string>();
   for (const value of endpointUrls(card)) {
     let parsed: URL;
     try {
@@ -143,8 +106,19 @@ async function assertPublicEndpoints(card: unknown): Promise<void> {
         `agent card endpoint "${value}" points at a private/loopback host and is blocked (SSRF guard). `
         + 'Set CYCGRAPH_ALLOW_PRIVATE_A2A_URLS=true to allow it in development.');
     }
-    await assertEndpointResolvesPublic(parsed, value);
+    if (!hosts.has(parsed.hostname)) hosts.set(parsed.hostname, value);
   }
+
+  const resolving = Promise.all([...hosts].map(([hostname, value]) =>
+    assertResolvedHostPublic(hostname, {
+      allowEnvVar: ALLOW_PRIVATE_ENV,
+      subject: `agent card endpoint "${value}"`,
+    }))).then(() => undefined);
+  await (signal
+    ? raceAbort(resolving, signal, () => new Error(
+      'agent card endpoint SSRF validation did not complete before the caller aborted (SSRF guard)',
+      { cause: signal.reason }))
+    : resolving);
 }
 
 /**
@@ -225,7 +199,7 @@ export function sdkClientFactory(options: SdkClientFactoryOptions = {}): CreateS
     const resolved = await card;
     // Checked per call, not per resolution: the card is cached, and the
     // guard must hold for cached reuse too.
-    await assertPublicEndpoints(resolved);
+    await assertPublicEndpoints(resolved, signal);
     // Cast: the resolver returns parsed JSON; the factory validates it.
     return factory.createFromAgentCard(resolved as never);
   };

--- a/packages/a2a/src/connection.ts
+++ b/packages/a2a/src/connection.ts
@@ -12,6 +12,7 @@
  * @module connection
  */
 
+import { lookup as dnsLookup } from 'node:dns/promises';
 import { ClientFactory, DefaultAgentCardResolver, JsonRpcTransportFactory } from '@a2a-js/sdk/client';
 import type { Client as SdkClient } from '@a2a-js/sdk/client';
 import { isPrivateOrLoopbackHost } from '@cycgraph/orchestrator';
@@ -64,14 +65,65 @@ function endpointUrls(card: unknown): string[] {
   return urls.filter((value): value is string => typeof value === 'string' && value !== '');
 }
 
+/** Max time spent resolving one endpoint host before the guard fails closed. */
+const DNS_LOOKUP_TIMEOUT_MS = 5000;
+
+/**
+ * Connect-time DNS re-check for one card endpoint host. The literal-hostname
+ * test above only sees the string the remote advertised: a public-looking
+ * name whose record points at `127.0.0.1`, `169.254.169.254`, or an RFC1918
+ * address passes it, and the SDK's own `fetch` then resolves that name and
+ * connects to the private address (DNS rebinding). Resolving here and
+ * rejecting if ANY returned address is private closes the static case.
+ *
+ * Fails closed: a lookup that errors or outruns its budget blocks the
+ * endpoint rather than letting the transport connect unvalidated. A TTL-0
+ * attacker who flips the record between this lookup and the SDK's connect
+ * is a documented residual — pair with network egress policy for that.
+ */
+async function assertEndpointResolvesPublic(parsed: URL, value: string): Promise<void> {
+  // URL.hostname keeps IPv6 in brackets; dns.lookup wants the bare address.
+  const host = parsed.hostname.replace(/^\[|\]$/g, '');
+  // Literal IPs were fully decided by isPrivateOrLoopbackHost — nothing to resolve.
+  if (/^[0-9.]+$/.test(host) || host.includes(':')) return;
+
+  let addresses: Array<{ address: string }>;
+  try {
+    const timeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`lookup timed out after ${DNS_LOOKUP_TIMEOUT_MS}ms`)),
+        DNS_LOOKUP_TIMEOUT_MS);
+      // A pending guard must not hold the process open.
+      (timer as { unref?: () => void }).unref?.();
+    });
+    addresses = await Promise.race([dnsLookup(host, { all: true, verbatim: true }), timeout]);
+  } catch (error) {
+    throw new Error(
+      `agent card endpoint "${value}" host "${host}" could not be resolved for SSRF validation: `
+      + `${(error as Error).message}`,
+      { cause: error });
+  }
+
+  const blocked = addresses.filter((entry) => isPrivateOrLoopbackHost(entry.address));
+  if (blocked.length > 0) {
+    throw new Error(
+      `agent card endpoint "${value}" resolves to a private/loopback address `
+      + `(${blocked.map((entry) => entry.address).join(', ')}) and is blocked (SSRF guard). `
+      + 'Set CYCGRAPH_ALLOW_PRIVATE_A2A_URLS=true to allow it in development.');
+  }
+}
+
 /**
  * SSRF guard over the endpoints a resolved Agent Card offers. The
  * registry validates the CARD url before any request leaves, but the
  * card's returned RPC endpoints come from the remote — a compromised
  * agent could point the transport at loopback or cloud-metadata hosts.
- * Honors the card-url guard's opt-out: one protocol, one decision.
+ * Each endpoint is checked as a literal host AND re-checked against its
+ * DNS-resolved addresses, so a public name pointing at a private address
+ * is refused too. Honors the card-url guard's opt-out: one protocol, one
+ * decision.
  */
-function assertPublicEndpoints(card: unknown): void {
+async function assertPublicEndpoints(card: unknown): Promise<void> {
   if (process.env['CYCGRAPH_ALLOW_PRIVATE_A2A_URLS'] === 'true') return;
   for (const value of endpointUrls(card)) {
     let parsed: URL;
@@ -91,6 +143,7 @@ function assertPublicEndpoints(card: unknown): void {
         `agent card endpoint "${value}" points at a private/loopback host and is blocked (SSRF guard). `
         + 'Set CYCGRAPH_ALLOW_PRIVATE_A2A_URLS=true to allow it in development.');
     }
+    await assertEndpointResolvesPublic(parsed, value);
   }
 }
 
@@ -172,7 +225,7 @@ export function sdkClientFactory(options: SdkClientFactoryOptions = {}): CreateS
     const resolved = await card;
     // Checked per call, not per resolution: the card is cached, and the
     // guard must hold for cached reuse too.
-    assertPublicEndpoints(resolved);
+    await assertPublicEndpoints(resolved);
     // Cast: the resolver returns parsed JSON; the factory validates it.
     return factory.createFromAgentCard(resolved as never);
   };

--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -3,10 +3,16 @@
  * per-request fetch its transport issues.
  */
 
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+vi.mock('node:dns/promises', () => ({ lookup: dnsLookupMock }));
+
 import { requestFetch, sdkClientFactory } from '../src/connection.js';
 
 const CARD_URL = 'http://agent.example';
+const PUBLIC_IP = '93.184.216.34';
+const METADATA_IP = '169.254.169.254';
 
 function cardResponse(endpointUrl = `${CARD_URL}/rpc`, extra: Record<string, unknown> = {}): Response {
   return new Response(JSON.stringify({
@@ -27,6 +33,11 @@ function cardResponse(endpointUrl = `${CARD_URL}/rpc`, extra: Record<string, unk
 async function settled(promise: Promise<unknown>): Promise<void> {
   await promise.catch(() => undefined);
 }
+
+beforeEach(() => {
+  dnsLookupMock.mockReset();
+  dnsLookupMock.mockResolvedValue([{ address: PUBLIC_IP, family: 4 }]);
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -165,6 +176,54 @@ describe('sdkClientFactory', () => {
     const create = sdkClientFactory();
 
     await expect(create(CARD_URL, {})).rejects.toThrow('must use http(s)');
+  });
+
+  it('refuses a card whose public endpoint host resolves to a private address', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: METADATA_IP, family: 4 }]);
+    const fetchMock = vi.fn(async () => cardResponse('https://rebind.example/rpc'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+
+    await expect(create(CARD_URL, {})).rejects.toThrow(
+      'agent card endpoint "https://rebind.example/rpc" resolves to a private/loopback address (169.254.169.254)');
+  });
+
+  it('refuses a card whose secondary endpoint host resolves to a private address', async () => {
+    dnsLookupMock.mockImplementation(async (host: string) =>
+      (host === 'rebind.example' ? [{ address: METADATA_IP, family: 4 }] : [{ address: PUBLIC_IP, family: 4 }]));
+    const fetchMock = vi.fn(async () => cardResponse(`${CARD_URL}/rpc`, {
+      additionalInterfaces: [{ url: 'https://rebind.example/rpc', transport: 'JSONRPC' }],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+
+    await expect(create(CARD_URL, {})).rejects.toThrow(
+      'agent card endpoint "https://rebind.example/rpc" resolves to a private/loopback address (169.254.169.254)');
+  });
+
+  it('refuses a card endpoint whose host cannot be resolved', async () => {
+    dnsLookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+    const fetchMock = vi.fn(async () => cardResponse('https://unknown.example/rpc'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+
+    await expect(create(CARD_URL, {})).rejects.toThrow(
+      'agent card endpoint "https://unknown.example/rpc" host "unknown.example" could not be resolved '
+      + 'for SSRF validation: ENOTFOUND');
+  });
+
+  it('skips the dns re-check under the development opt-out', async () => {
+    vi.stubEnv('CYCGRAPH_ALLOW_PRIVATE_A2A_URLS', 'true');
+    const fetchMock = vi.fn(async () => cardResponse('http://127.0.0.1:9999/rpc'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    await settled(create(CARD_URL, {}));
+
+    expect(dnsLookupMock).toHaveBeenCalledTimes(0);
   });
 
   it('accepts a card whose secondary endpoints are all public', async () => {

--- a/packages/a2a/test/connection.test.ts
+++ b/packages/a2a/test/connection.test.ts
@@ -186,7 +186,8 @@ describe('sdkClientFactory', () => {
     const create = sdkClientFactory();
 
     await expect(create(CARD_URL, {})).rejects.toThrow(
-      'agent card endpoint "https://rebind.example/rpc" resolves to a private/loopback address (169.254.169.254)');
+      'agent card endpoint "https://rebind.example/rpc" host "rebind.example" '
+      + 'resolves to a private/loopback address (169.254.169.254)');
   });
 
   it('refuses a card whose secondary endpoint host resolves to a private address', async () => {
@@ -200,7 +201,8 @@ describe('sdkClientFactory', () => {
     const create = sdkClientFactory();
 
     await expect(create(CARD_URL, {})).rejects.toThrow(
-      'agent card endpoint "https://rebind.example/rpc" resolves to a private/loopback address (169.254.169.254)');
+      'agent card endpoint "https://rebind.example/rpc" host "rebind.example" '
+      + 'resolves to a private/loopback address (169.254.169.254)');
   });
 
   it('refuses a card endpoint whose host cannot be resolved', async () => {
@@ -224,6 +226,52 @@ describe('sdkClientFactory', () => {
     await settled(create(CARD_URL, {}));
 
     expect(dnsLookupMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('resolves a host shared by several endpoints once', async () => {
+    const fetchMock = vi.fn(async () => cardResponse('https://agent.example/rpc', {
+      supportedInterfaces: [{ url: 'https://agent.example/jsonrpc', transport: 'JSONRPC' }],
+      additionalInterfaces: [{ url: 'https://agent.example/extra', transport: 'JSONRPC' }],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    await settled(create(CARD_URL, {}));
+
+    expect(dnsLookupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves distinct endpoint hosts concurrently', async () => {
+    let secondStarted!: () => void;
+    const secondHasStarted = new Promise<void>((resolve) => { secondStarted = resolve; });
+    dnsLookupMock.mockImplementation(async (host: string) => {
+      if (host === 'two.example') secondStarted();
+      else await secondHasStarted;
+      return [{ address: PUBLIC_IP, family: 4 }];
+    });
+    const fetchMock = vi.fn(async () => cardResponse('https://one.example/rpc', {
+      additionalInterfaces: [{ url: 'https://two.example/rpc', transport: 'JSONRPC' }],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const create = sdkClientFactory();
+    await settled(create(CARD_URL, {}));
+
+    expect(dnsLookupMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails the guard when the caller aborts before the dns re-check settles', async () => {
+    dnsLookupMock.mockImplementation(() => new Promise(() => undefined));
+    const fetchMock = vi.fn(async () => cardResponse('https://slow.example/rpc'));
+    vi.stubGlobal('fetch', fetchMock);
+    const caller = new AbortController();
+
+    const create = sdkClientFactory();
+    const creating = create(CARD_URL, {}, caller.signal);
+    caller.abort();
+
+    await expect(creating).rejects.toThrow(
+      'agent card endpoint SSRF validation did not complete before the caller aborted (SSRF guard)');
   });
 
   it('accepts a card whose secondary endpoints are all public', async () => {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -49,6 +49,8 @@ export type {
   SecurityPolicyEffect,
 } from './security/security-policy.js';
 export { SecurityPolicyViolationError, readableTaintedKeys } from './security/security-policy.js';
+export { assertResolvedHostPublic } from './security/dns-rebinding.js';
+export type { ResolvedHostGuardOptions } from './security/dns-rebinding.js';
 export { createObserverMiddleware } from './execution/middleware/observer-middleware.js';
 export type { ObserverMiddlewareOptions, ObserverFinding, ObserverSeverity, DiagnosticAgentOptions } from './execution/middleware/observer-middleware.js';
 export { BudgetExceededError, WorkflowTimeoutError, NodeConfigError, CircuitBreakerOpenError, EventLogCorruptionError, UnsupportedNodeTypeError, NodeBudgetExceededError, NoMatchingEdgeError } from './execution/errors.js';

--- a/packages/orchestrator/src/security/dns-rebinding.ts
+++ b/packages/orchestrator/src/security/dns-rebinding.ts
@@ -1,0 +1,90 @@
+/**
+ * Connect-time DNS re-check shared by every protocol that accepts a
+ * remote-supplied URL.
+ *
+ * A literal-hostname guard only sees the string a peer advertised: a
+ * public-looking name whose record points at `127.0.0.1`,
+ * `169.254.169.254`, or an RFC1918 address passes it, and the transport
+ * then resolves that name and connects to the private address (DNS
+ * rebinding). Resolving here — against the same range/encoding logic as
+ * {@link isPrivateOrLoopbackHost} — closes the static case for all of
+ * them from one place.
+ *
+ * @module security/dns-rebinding
+ */
+
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isPrivateOrLoopbackHost } from '../tools/schema.js';
+
+/** Default budget for one lookup before the guard fails closed. */
+export const DNS_LOOKUP_TIMEOUT_MS = 5000;
+
+/** Options for {@link assertResolvedHostPublic}. */
+export interface ResolvedHostGuardOptions {
+  /**
+   * Operator escape hatch: the re-check is skipped when this environment
+   * variable is `'true'`. Pass the same name the caller's literal-host
+   * guard honors — one protocol, one decision.
+   */
+  allowEnvVar: string;
+  /**
+   * Phrase every message opens with, naming what is being checked —
+   * e.g. `MCP server "docs"` or `agent card endpoint "https://a/rpc"`.
+   */
+  subject: string;
+  /** Lookup budget in ms. Defaults to {@link DNS_LOOKUP_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}
+
+/**
+ * Assert `hostname` does not resolve to a private/loopback/link-local
+ * address. IPv6 brackets are stripped, and a literal IP resolves to
+ * itself so it is skipped — callers must decide literals with
+ * {@link isPrivateOrLoopbackHost} before calling this.
+ *
+ * Fails closed: a lookup that errors or outruns its budget throws rather
+ * than letting the transport connect unvalidated. A TTL-0 attacker who
+ * flips the record between this lookup and the transport's own connect is
+ * a documented residual — pair with network egress policy for that.
+ *
+ * @param hostname - Host to resolve, bracketed or bare.
+ * @param options - Env-var opt-out, message subject, and lookup budget.
+ * @throws {Error} When resolution fails, outruns the budget, or returns
+ * any private address.
+ */
+export async function assertResolvedHostPublic(
+  hostname: string,
+  options: ResolvedHostGuardOptions,
+): Promise<void> {
+  const { allowEnvVar, subject, timeoutMs = DNS_LOOKUP_TIMEOUT_MS } = options;
+  if (process.env[allowEnvVar] === 'true') return;
+
+  // URL.hostname keeps IPv6 in brackets; dns.lookup wants the bare address.
+  const host = hostname.replace(/^\[|\]$/g, '');
+  if (/^[0-9.]+$/.test(host) || host.includes(':')) return;
+
+  let addresses: Array<{ address: string }>;
+  try {
+    const timeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`lookup timed out after ${timeoutMs}ms`)),
+        timeoutMs);
+      // A pending guard must not hold the process open.
+      (timer as { unref?: () => void }).unref?.();
+    });
+    addresses = await Promise.race([dnsLookup(host, { all: true, verbatim: true }), timeout]);
+  } catch (error) {
+    throw new Error(
+      `${subject} host "${host}" could not be resolved for SSRF validation: `
+      + `${(error as Error).message}`,
+      { cause: error });
+  }
+
+  const blocked = addresses.filter((entry) => isPrivateOrLoopbackHost(entry.address));
+  if (blocked.length > 0) {
+    throw new Error(
+      `${subject} host "${host}" resolves to a private/loopback address `
+      + `(${blocked.map((entry) => entry.address).join(', ')}) and is blocked (SSRF guard). `
+      + `Set ${allowEnvVar}=true to allow it in development.`);
+  }
+}

--- a/packages/orchestrator/test/dns-rebinding.test.ts
+++ b/packages/orchestrator/test/dns-rebinding.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared connect-time DNS re-check — unit tests for
+ * src/security/dns-rebinding.ts.
+ */
+
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+vi.mock('node:dns/promises', () => ({ lookup: dnsLookupMock }));
+
+import { assertResolvedHostPublic } from '../src/security/dns-rebinding.js';
+
+const PUBLIC_IP = '93.184.216.34';
+const METADATA_IP = '169.254.169.254';
+const OPTIONS = { allowEnvVar: 'CYCGRAPH_ALLOW_PRIVATE_TEST_URLS', subject: 'test subject "x"' };
+
+beforeEach(() => {
+  dnsLookupMock.mockReset();
+  dnsLookupMock.mockResolvedValue([{ address: PUBLIC_IP, family: 4 }]);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('assertResolvedHostPublic', () => {
+  it('accepts a host whose addresses are all public', async () => {
+    await expect(assertResolvedHostPublic('public.example', OPTIONS)).resolves.toBeUndefined();
+
+    expect(dnsLookupMock).toHaveBeenCalledWith('public.example', { all: true, verbatim: true });
+  });
+
+  it('rejects a host that resolves to a private address', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: METADATA_IP, family: 4 }]);
+
+    await expect(assertResolvedHostPublic('rebind.example', OPTIONS)).rejects.toThrow(
+      'test subject "x" host "rebind.example" resolves to a private/loopback address (169.254.169.254) '
+      + 'and is blocked (SSRF guard). Set CYCGRAPH_ALLOW_PRIVATE_TEST_URLS=true to allow it in development.');
+  });
+
+  it('fails closed when the lookup errors', async () => {
+    dnsLookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+
+    await expect(assertResolvedHostPublic('unknown.example', OPTIONS)).rejects.toThrow(
+      'test subject "x" host "unknown.example" could not be resolved for SSRF validation: ENOTFOUND');
+  });
+
+  it('skips the lookup when the named env var opts out', async () => {
+    vi.stubEnv('CYCGRAPH_ALLOW_PRIVATE_TEST_URLS', 'true');
+    dnsLookupMock.mockResolvedValue([{ address: METADATA_IP, family: 4 }]);
+
+    await expect(assertResolvedHostPublic('rebind.example', OPTIONS)).resolves.toBeUndefined();
+    expect(dnsLookupMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('skips the lookup for a literal ipv4 host', async () => {
+    await expect(assertResolvedHostPublic('93.184.216.34', OPTIONS)).resolves.toBeUndefined();
+    expect(dnsLookupMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('skips the lookup for a bracketed ipv6 host', async () => {
+    await expect(assertResolvedHostPublic('[2606:2800:220:1:248:1893:25c8:1946]', OPTIONS))
+      .resolves.toBeUndefined();
+    expect(dnsLookupMock).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## Summary

Filed by maintenance discovery (core-upkeep or repo-audit), approved by label, fixed by the issue-fix workflow. Closes #220. the tree was changed; the reviewer judges fidelity to the audited finding

## Changes

- Closes #220. the tree was changed; the reviewer judges fidelity to the audited finding

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New tests added for new functionality (unit + integration as appropriate)
- [ ] Tested manually (describe how — link a runnable example if you wrote one)

## Quality checklist

- [ ] Code follows the [coding standards](.claude/CLAUDE.md)
- [ ] Zod schemas added for any new input/output boundary
- [ ] No direct state mutation — all changes flow through reducers
- [ ] ES module imports use the `.js` extension
- [ ] Cross-workspace imports use `@cycgraph/*` package names, not relative paths
- [ ] No secrets, API keys, or `.env` contents in code or tests
- [ ] No new `console.warn` / `console.error` for things that should be observable — emit a stream event or use `createLogger`

## Database & data integrity

_Skip this block if the PR doesn't touch `packages/orchestrator-postgres` or the memory schemas._

- [ ] If you added a column, generated a migration: `npx drizzle-kit generate --config=packages/orchestrator-postgres/drizzle.config.ts`
- [ ] Migration is forward-only and reversible by a follow-up migration (no destructive `ALTER COLUMN ... SET DATA TYPE` without `USING`)
- [ ] If you renamed an enum or column, you wrote a backfill — old rows are still loadable
- [ ] Cascade behavior on new FKs is intentional (`cascade` vs `restrict` vs `set null`)
- [ ] Indexes added for any new hot-path query

## Security

_Skip this block if the PR doesn't touch agent permissions, MCP, taint, or budgets._

- [ ] Permissions narrow (`read_keys` / `write_keys`) — no new `'*'` grants without justification
- [ ] External MCP tool output flows through taint propagation
- [ ] No new code paths bypass `validateAction()`
- [ ] Budgets and `max_iterations` ceilings still apply along any new execution path

## Changeset

- [ ] Ran `npx changeset` and selected the right semver bump (`patch` / `minor` / `major`)
- [ ] Or: explicitly marked this PR as docs / tests / evals-only (no changeset needed — see `.changeset/README.md`)

## Related issues

Closes #

## Provenance

issue-fix: the finding was re-located mechanically, fixed by an agent in a jailed clone, and verified by re-scan, a class-specific anti-gaming guard, and repository checks before commit.
